### PR TITLE
Update information on alias flag

### DIFF
--- a/content/docs/configuration-system/content.md
+++ b/content/docs/configuration-system/content.md
@@ -96,10 +96,10 @@ Looking at our configuration again we can see that we have created the shorthand
 
 ```
 
-This shorthand can now further be used in the `-r | --repo` flag while executing
+This shorthand can now further be used in the `-R | --alias` flag while executing
 other commands:
 ```
-$ knoxite -r fort store latest .
+$ knoxite -R fort store latest .
 ...
 ```
 


### PR DESCRIPTION
We're now using the `-R | --alias` flag instead of the `-r | --repository` flag.