### PR TITLE
Add `pedantic` option to example config

### DIFF
--- a/content/docs/configuration-system/content.md
+++ b/content/docs/configuration-system/content.md
@@ -41,6 +41,7 @@ this:
     compression = "gzip"
     tolerance = 0
     encryption = ""
+    pedantic = true
     store_excludes = ["dont/store/this/folder*", "and/this/file"]
     restore_excludes = ["dont/restore/this/folder*"]
 ```


### PR DESCRIPTION
Let `pedantic` show up in the first example configuration to let people know that you can set this value in the config.